### PR TITLE
docs: Add Markdown documentation for UserInfo API

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,108 @@
+# UPortal API Documentation
+
+This document provides details about the available API endpoints for the UPortal application.
+
+## Authentication
+
+All API endpoints require authentication. Clients should use Azure AD authentication, and the necessary cookies established by the main application will be used for authorizing API requests. If a request is made without proper authentication, the API will return an HTTP `401 Unauthorized` status.
+
+## Endpoints
+
+### UserInfo API (`/api/userinfo`)
+
+This controller provides information about users, machines, and locations.
+
+#### 1. Get Current User Information
+
+*   **Endpoint:** `GET /api/userinfo/me`
+*   **Purpose:** Retrieves detailed information about the currently authenticated user.
+*   **Authentication:** Required.
+*   **Parameters:** None.
+*   **Responses:**
+    *   `200 OK`: Successfully retrieved user information.
+        ```json
+        {
+          "id": 1,
+          "name": "Test User",
+          "isAdmin": false,
+          "isActive": true,
+          "azureAdObjectId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+          "locationId": 10,
+          "locationName": "Main Office"
+        }
+        ```
+        *(Note: The structure matches `AppUserDto.cs`)*
+    *   `401 Unauthorized`: If the user is not authenticated.
+    *   `404 Not Found`: If the authenticated user's details cannot be found in the system.
+
+#### 2. Get Machine Information
+
+*   **Endpoint:** `GET /api/userinfo/machines`
+*   **Purpose:** Retrieves a list of machines. Can be filtered by user.
+*   **Authentication:** Required.
+*   **Parameters:**
+    *   `userId` (integer, optional): If provided, filters the machines to include only those assigned to the specified user ID.
+*   **Responses:**
+    *   `200 OK`: Successfully retrieved machine information.
+        ```json
+        [
+          {
+            "id": 101,
+            "name": "Desktop-ABC",
+            "locationName": "Main Office",
+            "assignedUserName": "Test User",
+            "locationId": 10,
+            "appUserId": 1
+          },
+          {
+            "id": 102,
+            "name": "Laptop-XYZ",
+            "locationName": "Remote Office",
+            "assignedUserName": "Another User",
+            "locationId": 20,
+            "appUserId": 2
+          }
+        ]
+        ```
+        *(Note: The structure matches `MachineDto.cs`. The list can be empty if no machines meet the criteria.)*
+    *   `401 Unauthorized`: If the user is not authenticated.
+
+#### 3. Get Location Information
+
+*   **Endpoint:** `GET /api/userinfo/locations`
+*   **Purpose:** Retrieves a list of all configured locations.
+*   **Authentication:** Required.
+*   **Parameters:** None.
+*   **Responses:**
+    *   `200 OK`: Successfully retrieved location information.
+        ```json
+        [
+          {
+            "id": 10,
+            "name": "Main Office",
+            "userCount": 15,
+            "machineCount": 25
+          },
+          {
+            "id": 20,
+            "name": "Remote Office",
+            "userCount": 5,
+            "machineCount": 8
+          }
+        ]
+        ```
+        *(Note: The structure matches `LocationDto.cs`. The list can be empty if no locations are configured.)*
+    *   `401 Unauthorized`: If the user is not authenticated.
+
+#### 4. Ping Test
+
+*   **Endpoint:** `GET /api/userinfo/ping`
+*   **Purpose:** A simple endpoint to check if the UserInfo API controller is responsive.
+*   **Authentication:** Required.
+*   **Parameters:** None.
+*   **Responses:**
+    *   `200 OK`: Controller is responsive. The response body will be a plain text string:
+        ```text
+        Pong from UserInfoController
+        ```
+    *   `401 Unauthorized`: If the user is not authenticated.

--- a/UPortal.Tests/Controllers/UserInfoControllerTests.cs
+++ b/UPortal.Tests/Controllers/UserInfoControllerTests.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Net.Http; // For HttpClient
+using System.Net.Http.Json; // For ReadFromJsonAsync
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UPortal.Dtos;
+using System.Collections.Generic;
+using UPortal.Tests.Helpers; // Added
+using Microsoft.AspNetCore.TestHost; // Added
+using Microsoft.Extensions.DependencyInjection; // Added
+using Microsoft.AspNetCore.Authentication; // Added
+using Moq; // Added
+using UPortal.Services; // Required for IAppUserService, IMachineService, ILocationService
+using System.Linq; // Required for Enumerable.Empty and .All()
+
+
+namespace UPortal.Tests.Controllers
+{
+    [TestClass]
+    public class UserInfoControllerTests
+    {
+        private WebApplicationFactory<UPortal.Program> _factory;
+        private HttpClient _client;
+        private Mock<IAppUserService> _mockAppUserService;
+        private Mock<IMachineService> _mockMachineService;
+        private Mock<ILocationService> _mockLocationService;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _mockAppUserService = new Mock<IAppUserService>();
+            _mockMachineService = new Mock<IMachineService>();
+            _mockLocationService = new Mock<ILocationService>();
+
+            _factory = new WebApplicationFactory<UPortal.Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.AddAuthentication(TestAuthHandler.AuthenticationScheme)
+                            .AddScheme<TestAuthHandlerOptions, TestAuthHandler>(
+                                TestAuthHandler.AuthenticationScheme, options => {
+                                    options.DefaultAzureAdObjectId = "test-azure-ad-object-id"; // Consistent ID
+                                });
+
+                        // Replace real services with mocks
+                        services.AddScoped<IAppUserService>(_ => _mockAppUserService.Object);
+                        services.AddScoped<IMachineService>(_ => _mockMachineService.Object);
+                        services.AddScoped<ILocationService>(_ => _mockLocationService.Object);
+                    });
+                });
+            _client = _factory.CreateClient();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            _client?.Dispose();
+            _factory?.Dispose();
+        }
+
+        [TestMethod]
+        public async Task GetCurrentUser_Unauthenticated_ReturnsUnauthorized()
+        {
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/me");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Response status code should be Unauthorized.");
+        }
+
+        [TestMethod]
+        public async Task Ping_Unauthenticated_ReturnsUnauthorized()
+        {
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/ping");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Response status code should be Unauthorized.");
+        }
+
+        [TestMethod]
+        public async Task GetMachines_Unauthenticated_ReturnsUnauthorized()
+        {
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/machines");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Response status code should be Unauthorized.");
+        }
+
+        [TestMethod]
+        public async Task GetLocations_Unauthenticated_ReturnsUnauthorized()
+        {
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/locations");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Response status code should be Unauthorized.");
+        }
+
+        // TODO: Add tests for authenticated scenarios. This will require setting up
+        // a way to send authenticated requests. Common approaches include:
+        // 1. Mocking the authentication handler (e.g., using a TestAuthHandler).
+        //    This is often the most robust way for integration tests.
+        //    Example: services.AddAuthentication("TestScheme")
+        //                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("TestScheme", options => {});
+        //    And then adding a header to the client: _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("TestScheme");
+        //
+        // 2. Configuring the WebApplicationFactory to use a test user/principal for all requests.
+        //    builder.ConfigureTestServices(services => services.AddScoped<IUserProfileService, TestUserProfileService>());
+
+        // Example structure for an authenticated test (requires TestAuthHandler or similar):
+        // [TestMethod]
+        // public async Task GetCurrentUser_Authenticated_ReturnsOkAndUserData()
+        // {
+        //     // Arrange: Ensure _client is set up for authenticated requests
+        //     // (e.g., by configuring TestAuthHandler in WithWebHostBuilder)
+        //     // _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("TestScheme");
+
+        //     // Act
+        //     var response = await _client.GetAsync("/api/userinfo/me");
+
+        //     // Assert
+        //     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        //     var user = await response.Content.ReadFromJsonAsync<AppUserDto>();
+        //     Assert.IsNotNull(user);
+        //     Assert.AreEqual("Test User", user.Name); // Assuming TestAuthHandler provides these claims
+        // }
+
+        [TestMethod]
+        public async Task Ping_Authenticated_ReturnsOk()
+        {
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/ping");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.AreEqual("Pong from UserInfoController", content);
+        }
+
+        [TestMethod]
+        public async Task GetCurrentUser_Authenticated_ReturnsOkAndUserData()
+        {
+            // Arrange
+            var expectedUser = new AppUserDto {
+                Id = 1,
+                Name = "Test User",
+                AzureAdObjectId = "test-azure-ad-object-id",
+                LocationName = "Test Location",
+                IsActive = true,
+                IsAdmin = false
+            };
+            _mockAppUserService.Setup(s => s.GetByAzureAdObjectIdAsync("test-azure-ad-object-id"))
+                .ReturnsAsync(expectedUser);
+
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/me");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            var actualUser = await response.Content.ReadFromJsonAsync<AppUserDto>();
+            Assert.IsNotNull(actualUser);
+            Assert.AreEqual(expectedUser.Name, actualUser.Name);
+            Assert.AreEqual(expectedUser.AzureAdObjectId, actualUser.AzureAdObjectId);
+            Assert.AreEqual(expectedUser.LocationName, actualUser.LocationName);
+            Assert.AreEqual(expectedUser.IsActive, actualUser.IsActive);
+            Assert.AreEqual(expectedUser.IsAdmin, actualUser.IsAdmin);
+        }
+
+        [TestMethod]
+        public async Task GetMachines_Authenticated_ReturnsMachineData()
+        {
+            // Arrange
+            var expectedMachines = new List<MachineDto>
+            {
+                new MachineDto { Id = 1, Name = "Test Machine 1", AppUserId = 1, LocationName = "Location A" },
+                new MachineDto { Id = 2, Name = "Test Machine 2", AppUserId = 1, LocationName = "Location B" }
+            };
+            _mockMachineService.Setup(s => s.GetAllAsync()).ReturnsAsync(expectedMachines);
+
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/machines");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var actualMachines = await response.Content.ReadFromJsonAsync<List<MachineDto>>();
+            Assert.IsNotNull(actualMachines);
+            Assert.AreEqual(expectedMachines.Count, actualMachines.Count);
+            // Add more detailed assertions if necessary, e.g., comparing properties of individual machines
+            Assert.AreEqual(expectedMachines[0].Name, actualMachines[0].Name);
+        }
+
+        [TestMethod]
+        public async Task GetMachines_Authenticated_WithUserIdFilter_ReturnsFilteredData()
+        {
+            // Arrange
+            var userIdToFilter = 10;
+            var allMachines = new List<MachineDto>
+            {
+                new MachineDto { Id = 1, Name = "Machine1", AppUserId = userIdToFilter, LocationName = "LocationA" },
+                new MachineDto { Id = 2, Name = "Machine2", AppUserId = 20, LocationName = "LocationB" },
+                new MachineDto { Id = 3, Name = "Machine3", AppUserId = userIdToFilter, LocationName = "LocationC" }
+            };
+            // Note: The controller's GetMachines method calls GetAllAsync and then filters in memory.
+            // So, the mock setup is for GetAllAsync.
+            _mockMachineService.Setup(s => s.GetAllAsync()).ReturnsAsync(allMachines);
+
+            // Act
+            var response = await _client.GetAsync($"/api/userinfo/machines?userId={userIdToFilter}");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var filteredMachines = await response.Content.ReadFromJsonAsync<List<MachineDto>>();
+            Assert.IsNotNull(filteredMachines);
+            Assert.AreEqual(2, filteredMachines.Count, "Should only return machines for the specified user.");
+            Assert.IsTrue(filteredMachines.All(m => m.AppUserId == userIdToFilter), "All returned machines should have the correct AppUserId.");
+        }
+
+        [TestMethod]
+        public async Task GetMachines_Authenticated_WithUserIdFilter_NoMatchingMachines_ReturnsEmptyList()
+        {
+            // Arrange
+            var userIdToFilter = 999; // A user ID that has no machines
+            var allMachines = new List<MachineDto>
+            {
+                new MachineDto { Id = 1, Name = "Machine1", AppUserId = 10, LocationName = "LocationA" },
+                new MachineDto { Id = 2, Name = "Machine2", AppUserId = 20, LocationName = "LocationB" }
+            };
+            _mockMachineService.Setup(s => s.GetAllAsync()).ReturnsAsync(allMachines);
+
+            // Act
+            var response = await _client.GetAsync($"/api/userinfo/machines?userId={userIdToFilter}");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var filteredMachines = await response.Content.ReadFromJsonAsync<List<MachineDto>>();
+            Assert.IsNotNull(filteredMachines);
+            Assert.AreEqual(0, filteredMachines.Count, "Should return an empty list if no machines match the filter.");
+        }
+
+
+        [TestMethod]
+        public async Task GetLocations_Authenticated_ReturnsLocationData()
+        {
+            // Arrange
+            var expectedLocations = new List<LocationDto>
+            {
+                new LocationDto { Id = 1, Name = "Test Location A", MachineCount = 2, UserCount = 5 },
+                new LocationDto { Id = 2, Name = "Test Location B", MachineCount = 1, UserCount = 3 }
+            };
+            _mockLocationService.Setup(s => s.GetAllAsync()).ReturnsAsync(expectedLocations);
+
+            // Act
+            var response = await _client.GetAsync("/api/userinfo/locations");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var actualLocations = await response.Content.ReadFromJsonAsync<List<LocationDto>>();
+            Assert.IsNotNull(actualLocations);
+            Assert.AreEqual(expectedLocations.Count, actualLocations.Count);
+            // Add more detailed assertions if necessary
+            Assert.AreEqual(expectedLocations[0].Name, actualLocations[0].Name);
+        }
+    }
+}

--- a/UPortal.Tests/Helpers/TestAuthHandler.cs
+++ b/UPortal.Tests/Helpers/TestAuthHandler.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using System.Collections.Generic; // Required for List<Claim>
+
+namespace UPortal.Tests.Helpers
+{
+    public class TestAuthHandlerOptions : AuthenticationSchemeOptions
+    {
+        public string DefaultUserId { get; set; } = "test-user-id";
+        public string DefaultAzureAdObjectId { get; set; } = "default-azure-ad-object-id"; // Added for AzureAdObjectId
+        public string DefaultUserName { get; set; } = "Test User"; // Added for user name
+        // Add other default claims as needed
+    }
+
+    public class TestAuthHandler : AuthenticationHandler<TestAuthHandlerOptions>
+    {
+        public const string AuthenticationScheme = "Test";
+
+        public TestAuthHandler(
+            IOptionsMonitor<TestAuthHandlerOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, Options.DefaultUserId),
+                new Claim(ClaimTypes.Name, Options.DefaultUserName),
+                new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", Options.DefaultAzureAdObjectId),
+                // Add other claims as needed by the application, e.g., roles
+                // new Claim(ClaimTypes.Role, "Admin"),
+            };
+            var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/UPortal/Controllers/UserInfoController.cs
+++ b/UPortal/Controllers/UserInfoController.cs
@@ -1,0 +1,173 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization; // Required for [Authorize]
+using UPortal.Services; // For IAppUserService, IMachineService, ILocationService
+using UPortal.Dtos; // For AppUserDto, MachineDto, LocationDto
+using System.Threading.Tasks; // For Task
+using System.Security.Claims; // For ClaimsPrincipal and accessing user claims
+using Microsoft.Extensions.Logging; // For ILogger
+using System.Linq; // For .Where()
+using System.Collections.Generic; // For List<T>
+using System; // For Exception
+
+namespace UPortal.Controllers
+{
+    /// <summary>
+    /// Provides API endpoints for retrieving user-related information,
+    /// including details about the current user, their associated machines, and available locations.
+    /// All endpoints require user authentication.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize] // Ensures all actions in this controller require authentication
+    public class UserInfoController : ControllerBase
+    {
+        private readonly IAppUserService _appUserService;
+        private readonly IMachineService _machineService;
+        private readonly ILocationService _locationService;
+        private readonly ILogger<UserInfoController> _logger;
+
+        public UserInfoController(
+            IAppUserService appUserService,
+            IMachineService machineService,
+            ILocationService locationService,
+            ILogger<UserInfoController> logger)
+        {
+            _appUserService = appUserService;
+            _machineService = machineService;
+            _locationService = locationService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieves information for the currently authenticated user.
+        /// </summary>
+        /// <returns>An <see cref="AppUserDto"/> containing the user's details.</returns>
+        /// <response code="200">Returns the current user's information.</response>
+        /// <response code="401">If the user is not authenticated or the Azure AD Object ID is not found in token claims.</response>
+        /// <response code="404">If the user's details are not found in the system using the Azure AD Object ID.</response>
+        /// <response code="500">If an unexpected error occurs.</response>
+        [HttpGet("me")]
+        public async Task<IActionResult> GetCurrentUser()
+        {
+            var azureAdObjectId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier");
+
+            if (string.IsNullOrEmpty(azureAdObjectId))
+            {
+                _logger.LogWarning("Azure AD Object ID not found in token claims.");
+                return Unauthorized("Azure AD Object ID not found in token.");
+            }
+
+            _logger.LogInformation("Fetching user by Azure AD Object ID: {AzureAdObjectId}", azureAdObjectId);
+            var userDto = await _appUserService.GetByAzureAdObjectIdAsync(azureAdObjectId);
+
+            if (userDto == null)
+            {
+                _logger.LogWarning("User with Azure AD Object ID: {AzureAdObjectId} not found.", azureAdObjectId);
+                return NotFound();
+            }
+
+            _logger.LogInformation("Successfully fetched user with Azure AD Object ID: {AzureAdObjectId}", azureAdObjectId);
+            return Ok(userDto);
+        }
+
+        /// <summary>
+        /// A simple endpoint to check if the controller is responsive.
+        /// </summary>
+        /// <returns>A string "Pong from UserInfoController".</returns>
+        /// <response code="200">Indicates the controller is responsive.</response>
+        // Placeholder for future methods
+        [HttpGet("ping")]
+        public IActionResult Ping()
+        {
+            return Ok("Pong from UserInfoController");
+        }
+
+        /// <summary>
+        /// Retrieves a list of machines.
+        /// </summary>
+        /// <remarks>
+        /// If a <paramref name="userId"/> is provided, the list is filtered to machines associated with that user.
+        /// Otherwise, all machines accessible to the current user (or all machines, depending on service implementation) are returned.
+        /// The current implementation filters by `MachineDto.AppUserId` if `userId` is provided.
+        /// </remarks>
+        /// <param name="userId">Optional. The ID of the user for whom to filter machines.</param>
+        /// <returns>A list of <see cref="MachineDto"/> objects.</returns>
+        /// <response code="200">Returns a list of machines.</response>
+        /// <response code="500">If an unexpected error occurs while fetching machines.</response>
+        [HttpGet("machines")]
+        public async Task<IActionResult> GetMachines([FromQuery] int? userId)
+        {
+            try
+            {
+                _logger.LogInformation("Attempting to fetch machines. UserId filter: {UserId}", userId.HasValue ? userId.Value.ToString() : "None");
+
+                IEnumerable<MachineDto> machines;
+                var allMachines = await _machineService.GetAllAsync(); // Assuming this returns Task<List<MachineDto>> or Task<IEnumerable<MachineDto>>
+
+                if (allMachines == null)
+                {
+                    _logger.LogWarning("Machine service returned null for GetAllAsync.");
+                    // Return an empty list or handle as an error, depending on expected behavior
+                    machines = new List<MachineDto>();
+                }
+                else
+                {
+                    if (userId.HasValue)
+                    {
+                        _logger.LogInformation("Filtering machines for AppUserId: {AppUserId}", userId.Value);
+                        // Ensure MachineDto has AppUserId. Based on the prompt, it does.
+                        machines = allMachines.Where(m => m.AppUserId == userId.Value).ToList();
+                        _logger.LogInformation("Found {MachineCount} machines after filtering for AppUserId: {AppUserId}", machines.Count(), userId.Value);
+                    }
+                    else
+                    {
+                        machines = allMachines.ToList();
+                        _logger.LogInformation("Fetched {MachineCount} total machines.", machines.Count());
+                    }
+                }
+                return Ok(machines);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while fetching machines. UserId filter: {UserId}", userId.HasValue ? userId.Value.ToString() : "None");
+                return StatusCode(500, "An internal server error occurred while processing your request.");
+            }
+        }
+
+        /// <summary>
+        /// Retrieves a list of all available locations.
+        /// </summary>
+        /// <returns>A list of <see cref="LocationDto"/> objects.</returns>
+        /// <response code="200">Returns a list of locations.</response>
+        /// <response code="500">If an unexpected error occurs while fetching locations.</response>
+        [HttpGet("locations")]
+        public async Task<IActionResult> GetLocations()
+        {
+            try
+            {
+                _logger.LogInformation("Attempting to fetch all locations.");
+
+                IEnumerable<LocationDto> locations;
+                var allLocations = await _locationService.GetAllAsync(); // Assuming this returns Task<List<LocationDto>> or Task<IEnumerable<LocationDto>>
+
+                if (allLocations == null)
+                {
+                    _logger.LogWarning("Location service returned null for GetAllAsync.");
+                    locations = new List<LocationDto>(); // Gracefully handle null by returning an empty list
+                }
+                else
+                {
+                    locations = allLocations.ToList();
+                    _logger.LogInformation("Fetched {LocationCount} total locations.", locations.Count());
+                }
+
+                return Ok(locations);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while fetching locations.");
+                return StatusCode(500, "An internal server error occurred while processing your request.");
+            }
+        }
+    }
+}

--- a/UPortal/UPortal.csproj
+++ b/UPortal/UPortal.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +26,7 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This commit introduces an `API_DOCUMENTATION.md` file. This file provides user-facing documentation for the REST API endpoints available under `/api/userinfo`.

It includes details on:
- Authentication requirements.
- Endpoint paths and HTTP methods.
- Purpose of each endpoint.
- Request parameters.
- Example JSON response structures for `/me`, `/machines`, and `/locations`.
- Example text response for `/ping`.